### PR TITLE
fixed the crash.

### DIFF
--- a/QBImagePickerController/Classes/QBAssetCollectionViewController.m
+++ b/QBImagePickerController/Classes/QBAssetCollectionViewController.m
@@ -432,7 +432,7 @@
         if (self.showsHeaderButton) {
             if ((selected && self.selectedAssets.count == self.assets.count) ||
                (!selected && self.selectedAssets.count == self.assets.count - 1)) {
-                [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:[NSIndexPath indexPathForRow:0 inSection:0]] withRowAnimation:UITableViewRowAnimationFade];
+                [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationFade];
             }
         }
     } else {


### PR DESCRIPTION
Hello @questbeat,

If there are 3 photos in my iPhone and I set `maximumNumberOfSelection` equal 3, when I selected the last photo it will crash.

``` objective-c
QBImagePickerController *imagePicker = [QBImagePickerController new];
imagePicker.delegate = self;
imagePicker.allowsMultipleSelection = YES;
imagePicker.limitsMaximumNumberOfSelection = YES;
imagePicker.maximumNumberOfSelection = 3;
imagePicker.fullScreenLayoutEnabled = NO;
imagePicker.filterType = QBImagePickerFilterTypeAllPhotos;

UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:imagePicker];
navigation.modalPresentationStyle = UIModalPresentationFormSheet;
[self presentViewController:navigation animated:YES completion:NULL];
```

![2013-07-05 10 43 07](https://f.cloud.github.com/assets/1680868/751903/d9a64032-e520-11e2-9131-10a91771b1fc.png)

![2013-07-05 10 50 03](https://f.cloud.github.com/assets/1680868/751904/dd3d6f90-e520-11e2-9748-8cd6a35e4bb4.png)
