### PR TITLE
Use the designated initializer for init

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ If you want to install manually, download this repository and copy files in QBIm
     }
 
 ### Single Image Picker
-	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] init];
+	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] initWithStyle:UITableViewStylePlain];
 	imagePickerController.delegate = self;
 
 ### Multiple Image Picker
-	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] init];
+	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] initWithStyle:UITableViewStylePlain];
 	imagePickerController.delegate = self;
 	imagePickerController.allowsMultipleSelection = YES;
 
 ### Multiple Image Picker with Limitation
-	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] init];
+	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] initWithStyle:UITableViewStylePlain];
 	imagePickerController.delegate = self;
 	imagePickerController.allowsMultipleSelection = YES;
 	imagePickerController.minimumNumberOfSelection = 3;
 	imagePickerController.maximumNumberOfSelection = 6;
 
 ### Specify the Albums to Show
-	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] init];
+	QBImagePickerController *imagePickerController = [[QBImagePickerController alloc] initWithStyle:UITableViewStylePlain];
 	imagePickerController.delegate = self;
 	imagePickerController.groupTypes = @[
 	                                     @(ALAssetsGroupSavedPhotos),


### PR DESCRIPTION
By calling `-init`, the picker does not call `UITableViewController`'s designated initializer of `initWithStyle:`. In turn, the method `-setupProperties` is not called on the `QBImagePickerController` instance.