### PR TITLE
Fix bug in iOS 8 caused by Deleted Photos Album

### DIFF
--- a/Pod/Classes/QBAssetsCollectionViewController.m
+++ b/Pod/Classes/QBAssetsCollectionViewController.m
@@ -99,12 +99,28 @@
     // Set title
     self.title = [self.assetsGroup valueForProperty:ALAssetsGroupPropertyName];
     
+    __block NSInteger photoCounter = 0;
+    
     // Get the number of photos and videos
     [self.assetsGroup setAssetsFilter:[ALAssetsFilter allPhotos]];
-    self.numberOfPhotos = self.assetsGroup.numberOfAssets;
+    [self.assetsGroup enumerateAssetsUsingBlock:^(ALAsset *result, NSUInteger index, BOOL *stop) {
+        if (result) {
+            photoCounter ++;
+        }
+    }];
+    
+    self.numberOfPhotos = photoCounter;
+
+    __block NSInteger videoCounter = 0;
     
     [self.assetsGroup setAssetsFilter:[ALAssetsFilter allVideos]];
-    self.numberOfVideos = self.assetsGroup.numberOfAssets;
+    [self.assetsGroup enumerateAssetsUsingBlock:^(ALAsset *result, NSUInteger index, BOOL *stop) {
+        if (result) {
+            videoCounter ++;
+        }
+    }];
+    
+    self.numberOfVideos = videoCounter;
     
     // Set assets filter
     [self.assetsGroup setAssetsFilter:ALAssetsFilterFromQBImagePickerControllerFilterType(self.filterType)];

--- a/Pod/Classes/QBAssetsCollectionViewController.m
+++ b/Pod/Classes/QBAssetsCollectionViewController.m
@@ -207,7 +207,7 @@
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
 {
-    return self.assetsGroup.numberOfAssets;
+    return self.assets.count;
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath

--- a/Pod/Classes/QBImagePickerGroupCell.m
+++ b/Pod/Classes/QBImagePickerGroupCell.m
@@ -70,7 +70,17 @@
     
     // Update label
     self.nameLabel.text = [self.assetsGroup valueForProperty:ALAssetsGroupPropertyName];
-    self.countLabel.text = [NSString stringWithFormat:@"%ld", (long)self.assetsGroup.numberOfAssets];
+    
+    __block NSInteger counter = 0;
+    
+    // Get the number of photos and videos
+    [self.assetsGroup enumerateAssetsUsingBlock:^(ALAsset *result, NSUInteger index, BOOL *stop) {
+        if (result) {
+            counter ++;
+        }
+    }];
+    
+    self.countLabel.text = [NSString stringWithFormat:@"%ld", counter];
 }
 
 @end


### PR DESCRIPTION
QBAssetsCollectionViewController was using the
assetsGroup to supply the count of cells for the
CollectionView. Switched to the assets array which
does not contain the nil deleted assets.

Fixes issue #28