### PR TITLE
Add missing strings for Japanese localization.

### DIFF
--- a/Pod/Assets/ja.lproj/QBImagePickerController.strings
+++ b/Pod/Assets/ja.lproj/QBImagePickerController.strings
@@ -8,6 +8,11 @@
 
 "title" = "アルバム";
 
-"format_photos_and_videos" = "写真%ld枚、ビデオ%ld本";
+"format_photo" = "写真%ld枚";
 "format_photos" = "写真%ld枚";
+"format_video" = "ビデオ%ld本";
 "format_videos" = "ビデオ%ld本";
+"format_photo_and_video" = "写真%ld枚、ビデオ%ld本";
+"format_photos_and_video" = "写真%ld枚、ビデオ%ld本";
+"format_photo_and_videos" = "写真%ld枚、ビデオ%ld本";
+"format_photos_and_videos" = "写真%ld枚、ビデオ%ld本";


### PR DESCRIPTION
Added missing localizable strings for Japanese to fix the issue that a string key, such as "format_photo", was displayed when only a photo or video existed in an asset group.

足りない日本語の文字列を追加しました。
