### PR TITLE
iPhone6/6Plus用のレイアウト調整

### DIFF
--- a/Demo/QBImagePickerControllerDemo/QBImagePickerControllerDemo-Info.plist
+++ b/Demo/QBImagePickerControllerDemo/QBImagePickerControllerDemo-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Main</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Pod/Classes/QBAssetsCollectionViewController.m
+++ b/Pod/Classes/QBAssetsCollectionViewController.m
@@ -312,6 +312,12 @@
         return CGSizeMake(151, 151);
     }
 
+    CGFloat screenHeight = [UIScreen mainScreen].bounds.size.height;
+    if (screenHeight == 667) {
+        return CGSizeMake(91.f, 91.f);
+    } else if (screenHeight == 736) {
+        return CGSizeMake(101.f, 101.f);
+    }
     return CGSizeMake(77.5, 77.5);
 }
 


### PR DESCRIPTION
ちょっと前の修正（直接masterにpushした）の差分が含まれていますが、
https://github.com/Fablic/QBImagePickerController/compare/iPhone6And6PlusLayout?expand=1#diff-cda462ec2cceca375b900c88e22fa79eR315 〜 https://github.com/Fablic/QBImagePickerController/compare/iPhone6And6PlusLayout?expand=1#diff-cda462ec2cceca375b900c88e22fa79eR320 のレビューをお願いします
