### PR TITLE
disable right to left languages for album list

### DIFF
--- a/QBImagePicker/QBImagePicker.storyboard
+++ b/QBImagePicker/QBImagePicker.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <scenes>
@@ -56,13 +57,13 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="tmU-WT-HVS">
-                                            <rect key="frame" x="102" y="22" width="465" height="20.5"/>
+                                            <rect key="frame" x="102" y="22" width="465" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of Photos" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KSh-gM-21m">
-                                            <rect key="frame" x="102" y="45.5" width="465" height="14.5"/>
+                                            <rect key="frame" x="102" y="46" width="465" height="15"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -156,7 +157,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                    <rect key="frame" x="0.0" y="0.0" width="77.5" height="77.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="78" height="78"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OyZ-If-PAI">

--- a/QBImagePicker/QBImagePicker.storyboard
+++ b/QBImagePicker/QBImagePicker.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <scenes>
         <!--Photos-->
@@ -57,28 +56,28 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Album Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="tmU-WT-HVS">
-                                            <rect key="frame" x="102" y="22" width="465" height="21"/>
+                                            <rect key="frame" x="102" y="22" width="465" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of Photos" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KSh-gM-21m">
-                                            <rect key="frame" x="102" y="46" width="465" height="15"/>
+                                            <rect key="frame" x="102" y="45.5" width="465" height="14.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="leading" secondItem="KSh-gM-21m" secondAttribute="leading" id="FAT-mK-OOf"/>
+                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="left" secondItem="KSh-gM-21m" secondAttribute="left" id="FAT-mK-OOf"/>
                                         <constraint firstAttribute="centerY" secondItem="K15-QT-84m" secondAttribute="centerY" id="FiC-XG-ndj"/>
                                         <constraint firstItem="KSh-gM-21m" firstAttribute="top" secondItem="tmU-WT-HVS" secondAttribute="bottom" constant="3" id="IPH-Jm-qHa"/>
-                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="leading" secondItem="K15-QT-84m" secondAttribute="trailing" constant="18" id="Luy-ym-eXv"/>
-                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="leading" secondItem="KSh-gM-21m" secondAttribute="leading" id="Ndc-6K-qLa"/>
-                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="trailing" secondItem="KSh-gM-21m" secondAttribute="trailing" id="Nuq-hu-Brn"/>
-                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="trailing" secondItem="KSh-gM-21m" secondAttribute="trailing" id="XdL-3v-qLb"/>
-                                        <constraint firstAttribute="trailing" secondItem="tmU-WT-HVS" secondAttribute="trailing" id="fgD-26-e0C"/>
-                                        <constraint firstItem="K15-QT-84m" firstAttribute="leading" secondItem="35j-da-VM3" secondAttribute="leading" constant="16" id="uN3-ge-sLh"/>
+                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="left" secondItem="K15-QT-84m" secondAttribute="right" constant="18" id="Luy-ym-eXv"/>
+                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="left" secondItem="KSh-gM-21m" secondAttribute="left" id="Ndc-6K-qLa"/>
+                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="right" secondItem="KSh-gM-21m" secondAttribute="right" id="Nuq-hu-Brn"/>
+                                        <constraint firstItem="tmU-WT-HVS" firstAttribute="right" secondItem="KSh-gM-21m" secondAttribute="right" id="XdL-3v-qLb"/>
+                                        <constraint firstAttribute="right" secondItem="tmU-WT-HVS" secondAttribute="right" id="fgD-26-e0C"/>
+                                        <constraint firstItem="K15-QT-84m" firstAttribute="left" secondItem="35j-da-VM3" secondAttribute="left" constant="16" id="uN3-ge-sLh"/>
                                         <constraint firstItem="KSh-gM-21m" firstAttribute="top" secondItem="tmU-WT-HVS" secondAttribute="bottom" constant="3" id="z63-JF-wJq"/>
                                         <constraint firstItem="tmU-WT-HVS" firstAttribute="top" secondItem="35j-da-VM3" secondAttribute="top" constant="22" id="zlZ-z9-21v"/>
                                     </constraints>
@@ -157,7 +156,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                    <rect key="frame" x="0.0" y="0.0" width="78" height="78"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="77.5" height="77.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OyZ-If-PAI">

--- a/QBImagePicker/QBImagePicker.storyboard
+++ b/QBImagePicker/QBImagePicker.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
     </dependencies>
     <scenes>
         <!--Photos-->


### PR DESCRIPTION
Album list for right to left languages doesn't looks good.
The Album thumbnail is located next to the navigation arrow to the right while the text is aligned to the left side of the screen without any padding.

This pull disables the "respect language direction" for leading and trailing alignments of the photo and the text