### PR TITLE
Removed custom sortDescriptors

### DIFF
--- a/QBImagePicker/QBAlbumsViewController.m
+++ b/QBImagePicker/QBAlbumsViewController.m
@@ -278,7 +278,6 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     PHAssetCollection *assetCollection = self.assetCollections[indexPath.row];
     
     PHFetchOptions *options = [PHFetchOptions new];
-    options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:YES]];
     
     switch (self.imagePickerController.mediaType) {
         case QBImagePickerMediaTypeImage:

--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -229,7 +229,6 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
 {
     if (self.assetCollection) {
         PHFetchOptions *options = [PHFetchOptions new];
-        options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:YES]];
         
         switch (self.imagePickerController.mediaType) {
             case QBImagePickerMediaTypeImage:


### PR DESCRIPTION
Fixes issue:  https://github.com/questbeat/QBImagePicker/issues/79

To simulate the exact behavious of the sorting in the native iOS photo app I did removed custom sortDescriptors. This is default behaviour provided by Apple and probably what most users expect. Sorting will still be done by `creationDate`
