### PR TITLE
Call reloadData in viewWillApear of QBAssetsViewController

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -102,6 +102,7 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     
     [self updateDoneButtonState];
     [self updateSelectionInfo];
+    [self.collectionView reloadData];
     
     // Scroll to bottom
     if (self.fetchResult.count > 0 && self.isMovingToParentViewController && !self.disableScrollToBottom) {


### PR DESCRIPTION
Container ViewController を使っている状況下で以下の様な画面遷移を作るとタイル上に並んでいる画面に表示される青いチェックマークが更新されません。

1. QBAssetsViewController で画像を選択する
2. この画面のまま別の ViewController に遷移する
  - 下のサンプルコードで `from` が `QBAssetsViewController` で `to` が別の VC のような感じです
3. 遷移先の VC から QBAssetsViewController に再び戻る
  - 下のサンプルコードで `to` が `QBAssetsViewController` のような感じです

3 で画面が再度表示された時に `reloadData` が呼ばれないためチェックマークが更新されないと思うので、 `viewWillApear:` で `reloadData` するようにしました.

大量に画像がある環境でこのように `reloadData` を呼び出して良いのか分かりませんが、レビューをお願いいたします :bow: 


```objc
- (void)changeViewController:(UIViewController *)from toViewController:(UIViewController *)to {

    [from willMoveToParentViewController:nil];

    [self addChildViewController:to];

    _presentingChildViewController = to;

    [self transitionFromViewController:from
                      toViewController:to
                              duration:0.3
                               options:UIViewAnimationOptionTransitionCrossDissolve
                            animations:nil
                            completion:^(BOOL finished) {

                                [from removeFromParentViewController];
                                [to didMoveToParentViewController:self];
                            }];
}
```
