### PR TITLE
Fix crashing issue for iOS 8 devices.

### DIFF
--- a/QBImagePicker.xcodeproj/project.pbxproj
+++ b/QBImagePicker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2CBC498F95A91A38C3E39BB3 /* ALAssetsLibrary+Singleton.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CBC448D44507A9877BE2578 /* ALAssetsLibrary+Singleton.m */; };
+		2CBC4FF91E01774F652C0D56 /* ALAssetsLibrary+Singleton.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CBC49598EA416A801FE45C3 /* ALAssetsLibrary+Singleton.h */; };
 		AA2107381AD15B74002B3E46 /* QBCheckmarkView.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2107321AD15B74002B3E46 /* QBCheckmarkView.h */; };
 		AA2107391AD15B74002B3E46 /* QBCheckmarkView.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2107331AD15B74002B3E46 /* QBCheckmarkView.m */; };
 		AA21073A1AD15B74002B3E46 /* QBVideoIconView.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2107341AD15B74002B3E46 /* QBVideoIconView.h */; };
@@ -78,6 +80,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2CBC448D44507A9877BE2578 /* ALAssetsLibrary+Singleton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ALAssetsLibrary+Singleton.m"; sourceTree = "<group>"; };
+		2CBC49598EA416A801FE45C3 /* ALAssetsLibrary+Singleton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ALAssetsLibrary+Singleton.h"; sourceTree = "<group>"; };
 		AA2107321AD15B74002B3E46 /* QBCheckmarkView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QBCheckmarkView.h; sourceTree = "<group>"; };
 		AA2107331AD15B74002B3E46 /* QBCheckmarkView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QBCheckmarkView.m; sourceTree = "<group>"; };
 		AA2107341AD15B74002B3E46 /* QBVideoIconView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QBVideoIconView.h; sourceTree = "<group>"; };
@@ -234,6 +238,8 @@
 				AA21073E1AD163CF002B3E46 /* ViewControllers */,
 				AA2107401AD163E3002B3E46 /* Resources */,
 				AACD2EF11AD12DB10029BE0B /* Supporting Files */,
+				2CBC448D44507A9877BE2578 /* ALAssetsLibrary+Singleton.m */,
+				2CBC49598EA416A801FE45C3 /* ALAssetsLibrary+Singleton.h */,
 			);
 			path = QBImagePicker;
 			sourceTree = "<group>";
@@ -318,6 +324,7 @@
 				AA7444C31AD14A5E006DE404 /* QBAssetsViewController.h in Headers */,
 				AA2107381AD15B74002B3E46 /* QBCheckmarkView.h in Headers */,
 				AA7444B31AD13948006DE404 /* QBAlbumCell.h in Headers */,
+				2CBC4FF91E01774F652C0D56 /* ALAssetsLibrary+Singleton.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -495,6 +502,7 @@
 				AA21073B1AD15B74002B3E46 /* QBVideoIconView.m in Sources */,
 				AA7444B41AD13948006DE404 /* QBAlbumCell.m in Sources */,
 				AA7444B61AD13948006DE404 /* QBAlbumsViewController.m in Sources */,
+				2CBC498F95A91A38C3E39BB3 /* ALAssetsLibrary+Singleton.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QBImagePicker/ALAssetsLibrary+Singleton.h
+++ b/QBImagePicker/ALAssetsLibrary+Singleton.h
@@ -1,0 +1,11 @@
+//
+// Created by Vlad Spreys on 12/8/15.
+// Copyright (c) 2015 Katsuma Tanaka. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AssetsLibrary/AssetsLibrary.h>
+
+@interface ALAssetsLibrary (Singleton)
++ (instancetype)defaultAssetsLibrary;
+@end

--- a/QBImagePicker/ALAssetsLibrary+Singleton.m
+++ b/QBImagePicker/ALAssetsLibrary+Singleton.m
@@ -1,0 +1,19 @@
+//
+// Created by Vlad Spreys on 12/8/15.
+// Copyright (c) 2015 Katsuma Tanaka. All rights reserved.
+//
+
+#import "ALAssetsLibrary+Singleton.h"
+
+@implementation ALAssetsLibrary (Singleton)
++ (instancetype)defaultAssetsLibrary {
+    static ALAssetsLibrary *defaultAssetsLibrary;
+    @synchronized(self) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            defaultAssetsLibrary = [[self alloc] init];
+        });
+    }
+    return defaultAssetsLibrary;
+}
+@end

--- a/QBImagePicker/QBImagePickerController.m
+++ b/QBImagePicker/QBImagePickerController.m
@@ -10,6 +10,7 @@
 
 // ViewControllers
 #import "QBAlbumsViewController.h"
+#import "ALAssetsLibrary+Singleton.h"
 
 @interface QBImagePickerController ()
 
@@ -45,7 +46,7 @@
         self.numberOfColumnsInPortrait = 4;
         self.numberOfColumnsInLandscape = 7;
         
-        self.assetsLibrary = [ALAssetsLibrary new];
+        self.assetsLibrary = [ALAssetsLibrary defaultAssetsLibrary];
         self.selectedAssetURLs = [NSMutableOrderedSet orderedSet];
         
         // Get asset bundle


### PR DESCRIPTION
*Steps to reproduce:*
1. Open QBImagePickerController application
2. Tap "Select Multiple Photos" option
3. Press "Cancel" button
4. Repeat steps 2 and 3 up to 20 times.

*Expected result:*
Application keeps running as normal

*Actual result:*
Application is crashing.

*Stacktrace:*

```
2015-12-08 14:33:33.517 QBImagePickerDemo[410:55898] *** Assertion
failure in __addContextToList_block_invoke(),
/SourceCache/PhotoLibraryServices/MobileSlideShow-2369/Sources/PLManaged
ObjectContext.m:2752
2015-12-08 14:33:33.526 QBImagePickerDemo[410:55898] *** Terminating
app due to uncaught exception 'NSInternalInconsistencyException',
reason: 'Too many contexts. No space in contextList
-[PLManagedObjectContext connectToChangeHub]'
*** First throw call stack:
(0x184286084 0x1948c40e4 0x184285f44 0x185105fc0 0x18ef24cfc
0x194f0949c 0x194f0945c 0x194f13554 0x194f0c564 0x194f15224 0x194f1675c
0x1950e52e4 0x1950e4fa8)
libc++abi.dylib: terminating with uncaught exception of type NSException
Signal: SIGABRT (signal SIGABRT)
Terminated due to signal 6
```

*Explanation of the issue:*

Issue is very well described by user3687252 on this Stackoverflow
conversation:
http://stackoverflow.com/questions/18901984/alassetslibrary-error-too-ma
ny-contexts-no-space-in-contextlist

*Affected Devices:*
Issue seems to be affecting iOS 8 devices. The crashing is not
reproducible on iOS 7 or iOS 9.