### PR TITLE
Added includeMoments to show Moments

### DIFF
--- a/QBImagePicker/QBAlbumsViewController.m
+++ b/QBImagePicker/QBAlbumsViewController.m
@@ -44,8 +44,8 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     [self setUpToolbarItems];
     
     // Fetch user albums and smart albums
-    PHFetchResult *smartAlbums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAny options:nil];
-    PHFetchResult *userAlbums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeAny options:nil];
+    PHFetchResult *smartAlbums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAny options:self.fetchOptionsForCollection];
+    PHFetchResult *userAlbums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeAny options:self.fetchOptionsForCollection];
     self.fetchResults = @[smartAlbums, userAlbums];
     
     [self updateAssetCollections];
@@ -185,10 +185,12 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
         }
 
         // Create the Moments album
-        NSBundle *bundle = self.imagePickerController.assetBundle;
-        NSString *momentsTitle = NSLocalizedStringFromTableInBundle(@"moments.title", @"QBImagePicker", bundle, nil);
-        PHAssetCollection *momentsCollection = [PHAssetCollection transientAssetCollectionWithAssets:assets title:momentsTitle];
-        [assetCollections addObject:momentsCollection];
+        if (assets.count > 0) {
+            NSBundle *bundle = self.imagePickerController.assetBundle;
+            NSString *momentsTitle = NSLocalizedStringFromTableInBundle(@"moments.title", @"QBImagePicker", bundle, nil);
+            PHAssetCollection *momentsCollection = [PHAssetCollection transientAssetCollectionWithAssets:assets title:momentsTitle];
+            [assetCollections addObject:momentsCollection];
+        }
     }
         
     // Fetch smart albums
@@ -295,6 +297,12 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
         default:
             break;
     }
+    return options;
+}
+
+- (PHFetchOptions*)fetchOptionsForCollection {
+    PHFetchOptions *options = [PHFetchOptions new];
+    options.predicate = [NSPredicate predicateWithFormat:@"estimatedAssetCount > 0"];
     return options;
 }
 

--- a/QBImagePicker/QBImagePickerController.h
+++ b/QBImagePicker/QBImagePickerController.h
@@ -48,4 +48,6 @@ typedef NS_ENUM(NSUInteger, QBImagePickerMediaType) {
 @property (nonatomic, assign) NSUInteger numberOfColumnsInPortrait;
 @property (nonatomic, assign) NSUInteger numberOfColumnsInLandscape;
 
+@property (nonatomic, assign) BOOL includeMoments;
+
 @end

--- a/QBImagePicker/QBImagePickerController.m
+++ b/QBImagePicker/QBImagePickerController.m
@@ -28,13 +28,15 @@
     
     if (self) {
         // Set default values
-        self.assetCollectionSubtypes = @[
-                                         @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-                                         @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
-                                         @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
-                                         @(PHAssetCollectionSubtypeSmartAlbumVideos),
-                                         @(PHAssetCollectionSubtypeSmartAlbumBursts)
-                                         ];
+        self.assetCollectionSubtypes = nil;     // nil to include all subtypes
+//        Else, set subtypes to filter
+//        self.assetCollectionSubtypes = @[
+//                                         @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+//                                         @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
+//                                         @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
+//                                         @(PHAssetCollectionSubtypeSmartAlbumVideos),
+//                                         @(PHAssetCollectionSubtypeSmartAlbumBursts)
+//                                         ];
         self.minimumNumberOfSelection = 1;
         self.numberOfColumnsInPortrait = 4;
         self.numberOfColumnsInLandscape = 7;

--- a/QBImagePicker/QBImagePickerController.m
+++ b/QBImagePicker/QBImagePickerController.m
@@ -38,6 +38,7 @@
         self.minimumNumberOfSelection = 1;
         self.numberOfColumnsInPortrait = 4;
         self.numberOfColumnsInLandscape = 7;
+        self.includeMoments = NO;
         
         _selectedAssets = [NSMutableOrderedSet orderedSet];
         

--- a/QBImagePicker/de.lproj/QBImagePicker.strings
+++ b/QBImagePicker/de.lproj/QBImagePicker.strings
@@ -19,3 +19,5 @@
 
 "assets.toolbar.item-selected" = "%ld Element ausgewählt";
 "assets.toolbar.items-selected" = "%ld Elemente ausgewählt";
+
+"moments.title" = "Moments";

--- a/QBImagePicker/en.lproj/QBImagePicker.strings
+++ b/QBImagePicker/en.lproj/QBImagePicker.strings
@@ -19,3 +19,5 @@
 
 "assets.toolbar.item-selected" = "%ld Item Selected";
 "assets.toolbar.items-selected" = "%ld Items Selected";
+
+"moments.title" = "Moments";

--- a/QBImagePicker/es.lproj/QBImagePicker.strings
+++ b/QBImagePicker/es.lproj/QBImagePicker.strings
@@ -19,3 +19,5 @@
 
 "assets.toolbar.item-selected" = "%ld items seleccionados";
 "assets.toolbar.items-selected" = "%ld items seleccionados";
+
+"moments.title" = "Moments";

--- a/QBImagePicker/ja.lproj/QBImagePicker.strings
+++ b/QBImagePicker/ja.lproj/QBImagePicker.strings
@@ -19,3 +19,5 @@
 
 "assets.toolbar.item-selected" = "%ld 項目を選択中";
 "assets.toolbar.items-selected" = "%ld 項目を選択中";
+
+"moments.title" = "Moments";

--- a/QBImagePicker/pl.lproj/QBImagePicker.strings
+++ b/QBImagePicker/pl.lproj/QBImagePicker.strings
@@ -19,3 +19,5 @@
 
 "assets.toolbar.item-selected" = "%ld zaznaczona rzecz";
 "assets.toolbar.items-selected" = "Zaznaczonych rzeczy: %ld";
+
+"moments.title" = "Moments";

--- a/QBImagePicker/zh-Hans.lproj/QBImagePicker.strings
+++ b/QBImagePicker/zh-Hans.lproj/QBImagePicker.strings
@@ -19,3 +19,5 @@
 
 "assets.toolbar.item-selected" = "选择了%ld项";
 "assets.toolbar.items-selected" = "选择了%ld项";
+
+"moments.title" = "Moments";

--- a/QBImagePickerDemo/ViewController.m
+++ b/QBImagePickerDemo/ViewController.m
@@ -30,6 +30,7 @@
     imagePickerController.mediaType = QBImagePickerMediaTypeAny;
     imagePickerController.allowsMultipleSelection = (indexPath.section == 1);
     imagePickerController.showsNumberOfSelectedAssets = YES;
+    imagePickerController.includeMoments = YES;
     
     if (indexPath.section == 1) {
         switch (indexPath.row) {


### PR DESCRIPTION
As per issue #125, I added the property `includeMoments` to show Moments as the first album.

My implementation is by merging the assets of multiple moments collections (yes, the fetch will be multiple collections), and then add them as a transient collection. This might not be the best way, but it is not slow either. Tested with 1000+ (photos and videos), and it still runs within a second.

If someone knows how to fetch all moments in 1 collection easily, please help.

Note: I added "Moments" to the string files, but without localising them. 
