### PR TITLE
Merge in AssetLibrary support for iOS 7.x

### DIFF
--- a/QBImagePicker/QBAssetsViewController.h
+++ b/QBImagePicker/QBAssetsViewController.h
@@ -10,10 +10,12 @@
 
 @class QBImagePickerController;
 @class PHAssetCollection;
+@class ALAssetsGroup;
 
 @interface QBAssetsViewController : UICollectionViewController
 
 @property (nonatomic, weak) QBImagePickerController *imagePickerController;
 @property (nonatomic, strong) PHAssetCollection *assetCollection;
+@property (nonatomic, strong) ALAssetsGroup *assetsGroup;
 
 @end

--- a/QBImagePicker/QBImagePickerController.h
+++ b/QBImagePicker/QBImagePickerController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <Photos/Photos.h>
+#import <AssetsLibrary/AssetsLibrary.h>
 
 @class QBImagePickerController;
 
@@ -17,9 +18,9 @@
 - (void)qb_imagePickerController:(QBImagePickerController *)imagePickerController didFinishPickingAssets:(NSArray *)assets;
 - (void)qb_imagePickerControllerDidCancel:(QBImagePickerController *)imagePickerController;
 
-- (BOOL)qb_imagePickerController:(QBImagePickerController *)imagePickerController shouldSelectAsset:(PHAsset *)asset;
-- (void)qb_imagePickerController:(QBImagePickerController *)imagePickerController didSelectAsset:(PHAsset *)asset;
-- (void)qb_imagePickerController:(QBImagePickerController *)imagePickerController didDeselectAsset:(PHAsset *)asset;
+- (BOOL)qb_imagePickerController:(QBImagePickerController *)imagePickerController shouldSelectAsset:(id)asset;
+- (void)qb_imagePickerController:(QBImagePickerController *)imagePickerController didSelectAsset:(id)asset;
+- (void)qb_imagePickerController:(QBImagePickerController *)imagePickerController didDeselectAsset:(id)asset;
 
 @end
 
@@ -29,13 +30,29 @@ typedef NS_ENUM(NSUInteger, QBImagePickerMediaType) {
     QBImagePickerMediaTypeVideo
 };
 
+typedef NS_ENUM(NSUInteger, QBImagePickerCollectionSubtype) {
+    
+    QBImagePickerCollectionSubtypeAll,
+    QBImagePickerCollectionSubtypeLibrary,
+    QBImagePickerCollectionSubtypeAlbum,
+    QBImagePickerCollectionSubtypeStream,
+    QBImagePickerCollectionSubtypePanoramas,
+    QBImagePickerCollectionSubtypeVideos,
+    QBImagePickerCollectionSubtypeBursts,
+
+};
+
 @interface QBImagePickerController : UIViewController
+
++ (BOOL) usingPhotosLibrary;
+
+@property (nonatomic, strong) ALAssetsLibrary *assetsLibrary;
 
 @property (nonatomic, weak) id<QBImagePickerControllerDelegate> delegate;
 
 @property (nonatomic, strong, readonly) NSMutableOrderedSet *selectedAssets;
 
-@property (nonatomic, copy) NSArray *assetCollectionSubtypes;
+@property (nonatomic, copy) NSArray *collectionSubtypes;
 @property (nonatomic, assign) QBImagePickerMediaType mediaType;
 
 @property (nonatomic, assign) BOOL allowsMultipleSelection;

--- a/QBImagePicker/QBImagePickerController.m
+++ b/QBImagePicker/QBImagePickerController.m
@@ -7,10 +7,10 @@
 //
 
 #import "QBImagePickerController.h"
-#import <Photos/Photos.h>
 
 // ViewControllers
 #import "QBAlbumsViewController.h"
+
 
 @interface QBImagePickerController ()
 
@@ -22,19 +22,24 @@
 
 @implementation QBImagePickerController
 
++ (BOOL) usingPhotosLibrary {
+
+    return (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_8_0);
+}
+
 - (instancetype)init
 {
     self = [super init];
     
     if (self) {
-        // Set default values
-        self.assetCollectionSubtypes = @[
-                                         @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-                                         @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
-                                         @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
-                                         @(PHAssetCollectionSubtypeSmartAlbumVideos),
-                                         @(PHAssetCollectionSubtypeSmartAlbumBursts)
-                                         ];
+        
+        if ([QBImagePickerController usingPhotosLibrary] == NO) {
+    
+            self.assetsLibrary = [ALAssetsLibrary new];
+        }
+        
+        self.collectionSubtypes = @[@(QBImagePickerCollectionSubtypeAll)];
+        
         self.minimumNumberOfSelection = 1;
         self.numberOfColumnsInPortrait = 4;
         self.numberOfColumnsInLandscape = 7;


### PR DESCRIPTION
Currently for the Podfile there are two versions, one using
PhotosLibrary and one AssetLibrary. The AssetLibrary version does not
produce high-quality thumbs, so for clients needing iOS 7 support this
means using the previous version and therefore all versions have to
suffer low-quality thumbs. Makes more sense just to support the legacy
AssetLibrary code from the previous version.  I took that code and
merged into into the current base so it’s supported side-by-side and
added a flag to the image controller that checks the Foundation
version. If the PhotoLibrary is available, it uses that, otherwise it
falls back to the AssetLibrary.  Couple notes: The delegate methods now
return either PHAssets or ALAssets depending on which OS is being run
(8 or 7, respectively).  Clients will need to check the OS version or
object class. Also changed assetCollectionSubtypes to
collectionSubtypes and added a more generic enum,
QBImagePickerCollectionSubtype. A new method in QBAlbumsViewController
(assetCollectionSubtypesForSubtypes:) maps the enum to the PhotoLibrary
or AssetLibrary specific types. Also worth noting that I didn’t really
spend time trying to map all the flags to one and another, so I mapped
a few that seemed reasonable and added an “All” subtype. The All
subtype maps to the set in the current version and the set in the
previous version.