### PR TITLE
Albums sync'd from iTunes were not showing up in the album picking screen

### DIFF
--- a/QBImagePicker/QBAlbumsViewController.m
+++ b/QBImagePicker/QBAlbumsViewController.m
@@ -160,7 +160,7 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
         [fetchResult enumerateObjectsUsingBlock:^(PHAssetCollection *assetCollection, NSUInteger index, BOOL *stop) {
             PHAssetCollectionSubtype subtype = assetCollection.assetCollectionSubtype;
             
-            if (subtype == PHAssetCollectionSubtypeAlbumRegular) {
+            if (subtype == PHAssetCollectionSubtypeAlbumRegular || subtype == PHAssetCollectionSubtypeAlbumSyncedAlbum) {
                 [userAlbums addObject:assetCollection];
             } else if ([assetCollectionSubtypes containsObject:@(subtype)]) {
                 if (!smartAlbums[@(subtype)]) {


### PR DESCRIPTION
Hello! I found a little bug where photos that were sync'd from iTunes were not showing up in the album choices. I'm not sure if this was intentional, but I added a little fix. If the iTunes-sync'd-folder-not-showing-up is part of the features (or if it's already been fixed and I just pulled an outdated branch), feel free to ignore this. Thanks! :)