### PR TITLE
No longer adding the index paths of non-cell elements in collection v…

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -46,8 +46,10 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     
     NSMutableArray *indexPaths = [NSMutableArray arrayWithCapacity:allLayoutAttributes.count];
     for (UICollectionViewLayoutAttributes *layoutAttributes in allLayoutAttributes) {
-        NSIndexPath *indexPath = layoutAttributes.indexPath;
-        [indexPaths addObject:indexPath];
+        if (layoutAttributes.representedElementCategory == UICollectionElementCategoryCell) {
+            NSIndexPath *indexPath = layoutAttributes.indexPath;
+            [indexPaths addObject:indexPath];
+        }
     }
     return indexPaths;
 }


### PR DESCRIPTION
This fixes a crash where you navigate to an empty folder.  This crash can be reproduced by setting the mediaType of a ```QBImagePickerController``` to ```QBImagePickerMediaTypeImage``` and choosing the empty 'videos' folder