### PR TITLE
Delay asset controller layout until frame is correct and layout is complete

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -105,8 +105,12 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     
     // Scroll to bottom
     if (self.fetchResult.count > 0 && self.isMovingToParentViewController && !self.disableScrollToBottom) {
-        NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.fetchResult.count - 1) inSection:0];
-        [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
+        // when presenting as a .FormSheet on iPad, the frame is not correct until just after viewWillAppear:
+        // dispatching to the main thread waits one run loop until the frame is update and the layout is complete
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.fetchResult.count - 1) inSection:0];
+            [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
+        });
     }
 }
 


### PR DESCRIPTION
When presenting as a .FormSheet on iPad, the frame is not correct until just after `viewWillAppear:`. Moving the `scrollToItem:` code to viewDidAppear is too late, and viewWillAppear is too early. Dispatching to the main thread waits one run loop until the frame is update and the layout is complete without being visible to the user.

possible fix for: https://github.com/questbeat/QBImagePicker/issues/157 and https://github.com/questbeat/QBImagePicker/issues/148
