### PR TITLE
Expose checkmark color for customisation.

### DIFF
--- a/QBImagePicker/QBAssetCell.h
+++ b/QBImagePicker/QBAssetCell.h
@@ -16,5 +16,6 @@
 @property (weak, nonatomic) IBOutlet QBVideoIndicatorView *videoIndicatorView;
 
 @property (nonatomic, assign) BOOL showsOverlayViewWhenSelected;
+@property (nonatomic) UIColor* checkmarkColor;
 
 @end

--- a/QBImagePicker/QBAssetCell.m
+++ b/QBImagePicker/QBAssetCell.m
@@ -7,10 +7,12 @@
 //
 
 #import "QBAssetCell.h"
+#import "QBCheckmarkView.h"
 
 @interface QBAssetCell ()
 
 @property (weak, nonatomic) IBOutlet UIView *overlayView;
+@property (weak, nonatomic) IBOutlet QBCheckmarkView *checkmarkView;
 
 @end
 
@@ -22,6 +24,12 @@
     
     // Show/hide overlay view
     self.overlayView.hidden = !(selected && self.showsOverlayViewWhenSelected);
+}
+
+-(void)setCheckmarkColor:(UIColor *)checkmarkColor
+{
+    _checkmarkColor = checkmarkColor;
+    self.checkmarkView.bodyColor = checkmarkColor;
 }
 
 @end

--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -443,6 +443,7 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     QBAssetCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"AssetCell" forIndexPath:indexPath];
     cell.tag = indexPath.item;
     cell.showsOverlayViewWhenSelected = self.imagePickerController.allowsMultipleSelection;
+    cell.checkmarkColor = self.imagePickerController.checkmarkColor;
     
     // Image
     PHAsset *asset = self.fetchResult[indexPath.item];

--- a/QBImagePicker/QBImagePicker.storyboard
+++ b/QBImagePicker/QBImagePicker.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -226,6 +227,7 @@
                                     </mask>
                                 </variation>
                                 <connections>
+                                    <outlet property="checkmarkView" destination="m99-yj-HSc" id="Dbh-Gd-gVA"/>
                                     <outlet property="imageView" destination="0aq-fn-r9R" id="smK-ma-TWL"/>
                                     <outlet property="overlayView" destination="uyS-Tg-Iyl" id="N6m-w2-m4M"/>
                                     <outlet property="videoIndicatorView" destination="BwJ-KE-LWZ" id="HkB-Dc-nzF"/>

--- a/QBImagePicker/QBImagePickerController.h
+++ b/QBImagePicker/QBImagePickerController.h
@@ -45,6 +45,8 @@ typedef NS_ENUM(NSUInteger, QBImagePickerMediaType) {
 @property (nonatomic, copy) NSString *prompt;
 @property (nonatomic, assign) BOOL showsNumberOfSelectedAssets;
 
+@property (nonatomic, copy) UIColor *checkmarkColor;
+
 @property (nonatomic, assign) NSUInteger numberOfColumnsInPortrait;
 @property (nonatomic, assign) NSUInteger numberOfColumnsInLandscape;
 


### PR DESCRIPTION
Exposing the checkmark body color property of the checkmark view for customization. At first I thought about propagating the tint color of the QBImagePickerController but decided against it as some people might want further customization.