### PR TITLE
Crash with deleted photos in iTunes library

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -407,8 +407,11 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
                     
                     NSIndexSet *changedIndexes = [collectionChanges changedIndexes];
                     if ([changedIndexes count]) {
-                        [self.collectionView reloadItemsAtIndexPaths:[changedIndexes qb_indexPathsFromIndexesWithSection:0]];
-                    }
+                        // We need to remove the removed images, since reloading them will cause a crash
+                        // "uncaught ObjC exception, reason: attempt to delete and reload the same index path"
+                        NSMutableIndexSet *changedWithoutRemovalsIndexes = [changedIndexes mutableCopy];
+                        [changedWithoutRemovalsIndexes removeIndexes:removedIndexes];
+                        [self.collectionView reloadItemsAtIndexPaths:[changedWithoutRemovalsIndexes qb_indexPathsFromIndexesWithSection:0]];
                 } completion:NULL];
             }
             


### PR DESCRIPTION
When syncing down deleted images from an iPhoto library, it crashes
because the path doesn’t exist anymore.

this commit fixes #171 
