### PR TITLE
Add support in the Picker to download iCloud image before returning

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -107,10 +107,10 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     if (self.fetchResult.count > 0 && self.isMovingToParentViewController && !self.disableScrollToBottom) {
         // when presenting as a .FormSheet on iPad, the frame is not correct until just after viewWillAppear:
         // dispatching to the main thread waits one run loop until the frame is update and the layout is complete
-        dispatch_async(dispatch_get_main_queue(), ^{
+        [self.collectionView performBatchUpdates:^{} completion: ^(BOOL finished) {
             NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.fetchResult.count - 1) inSection:0];
             [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
-        });
+        }];
     }
 }
 

--- a/QBImagePicker/QBImagePicker.storyboard
+++ b/QBImagePicker/QBImagePicker.storyboard
@@ -1,5 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -262,10 +265,23 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="activityContainerView" destination="LYR-It-Jht" id="J1p-mI-O1R"/>
+                        <outlet property="activityIndicator" destination="JJu-1L-0Pg" id="sSS-SO-kib"/>
                         <outlet property="doneButton" destination="nai-ZV-lR8" id="lxY-18-MpF"/>
                     </connections>
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qBb-2Q-SxP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <view hidden="YES" contentMode="scaleToFill" id="LYR-It-Jht" userLabel="ActivityIndicatorContainerView">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <subviews>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" hidesWhenStopped="YES" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="JJu-1L-0Pg">
+                            <rect key="frame" x="177" y="323" width="20" height="20"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                        </activityIndicatorView>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.65071875000000001" colorSpace="calibratedWhite"/>
+                </view>
             </objects>
             <point key="canvasLocation" x="1814" y="852"/>
         </scene>

--- a/QBImagePicker/QBImagePickerController.h
+++ b/QBImagePicker/QBImagePickerController.h
@@ -48,4 +48,6 @@ typedef NS_ENUM(NSUInteger, QBImagePickerMediaType) {
 @property (nonatomic, assign) NSUInteger numberOfColumnsInPortrait;
 @property (nonatomic, assign) NSUInteger numberOfColumnsInLandscape;
 
+@property (nonatomic, assign) BOOL downloadiCloudPhotos;
+
 @end


### PR DESCRIPTION
**What**
Adds support in QBImagePickerController to download photos which are not locally present on the device(i.e. are on iCloud). This by default will not happen, if the user of QBImagePickerController wants this functionality he has to set the downloadiCloudPhotos property of QBImagePickerController. On doing this the picker upon selection will download the image while showing an activity indicator while it download the image and once the image is ready it will make the delegate callback

**Why**
This helps if the picker is used in multiple places across the app, if this functionality isn't available in the picker the code to download iCloud images has to be written in all the places the picker is used.