### PR TITLE
fix: various crashes from crash reporter

### DIFF
--- a/QBImagePicker/QBAlbumsViewController.m
+++ b/QBImagePicker/QBAlbumsViewController.m
@@ -195,39 +195,39 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     UIGraphicsBeginImageContext(size);
     CGContextRef context = UIGraphicsGetCurrentContext();
     
-    UIColor *backgroundColor = [UIColor colorWithRed:(239.0 / 255.0) green:(239.0 / 255.0) blue:(244.0 / 255.0) alpha:1.0];
-    UIColor *iconColor = [UIColor colorWithRed:(179.0 / 255.0) green:(179.0 / 255.0) blue:(182.0 / 255.0) alpha:1.0];
+    UIColor *backgroundColor = [UIColor colorWithRed:(239.0f / 255.0f) green:(239.0f / 255.0f) blue:(244.0f / 255.0f) alpha:1.0f];
+    UIColor *iconColor = [UIColor colorWithRed:(179.0f / 255.0f) green:(179.0f / 255.0f) blue:(182.0f / 255.0f) alpha:1.0f];
     
     // Background
     CGContextSetFillColorWithColor(context, [backgroundColor CGColor]);
     CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height));
     
     // Icon (back)
-    CGRect backIconRect = CGRectMake(size.width * (16.0 / 68.0),
-                                     size.height * (20.0 / 68.0),
-                                     size.width * (32.0 / 68.0),
-                                     size.height * (24.0 / 68.0));
+    CGRect backIconRect = CGRectMake(size.width * (16.0f / 68.0f),
+                                     size.height * (20.0f / 68.0f),
+                                     size.width * (32.0f / 68.0f),
+                                     size.height * (24.0f / 68.0f));
     
     CGContextSetFillColorWithColor(context, [iconColor CGColor]);
     CGContextFillRect(context, backIconRect);
     
     CGContextSetFillColorWithColor(context, [backgroundColor CGColor]);
-    CGContextFillRect(context, CGRectInset(backIconRect, 1.0, 1.0));
+    CGContextFillRect(context, CGRectInset(backIconRect, 1.0f, 1.0f));
     
     // Icon (front)
-    CGRect frontIconRect = CGRectMake(size.width * (20.0 / 68.0),
-                                      size.height * (24.0 / 68.0),
-                                      size.width * (32.0 / 68.0),
-                                      size.height * (24.0 / 68.0));
+    CGRect frontIconRect = CGRectMake(size.width * (20.0f / 68.0f),
+                                      size.height * (24.0f / 68.0f),
+                                      size.width * (32.0f / 68.0f),
+                                      size.height * (24.0f / 68.0f));
     
     CGContextSetFillColorWithColor(context, [backgroundColor CGColor]);
-    CGContextFillRect(context, CGRectInset(frontIconRect, -1.0, -1.0));
+    CGContextFillRect(context, CGRectInset(frontIconRect, -1.0f, -1.0f));
     
     CGContextSetFillColorWithColor(context, [iconColor CGColor]);
     CGContextFillRect(context, frontIconRect);
     
     CGContextSetFillColorWithColor(context, [backgroundColor CGColor]);
-    CGContextFillRect(context, CGRectInset(frontIconRect, 1.0, 1.0));
+    CGContextFillRect(context, CGRectInset(frontIconRect, 1.0f, 1.0f));
     
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
@@ -276,7 +276,7 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
 {
     QBAlbumCell *cell = [tableView dequeueReusableCellWithIdentifier:@"AlbumCell" forIndexPath:indexPath];
     cell.tag = indexPath.row;
-    cell.borderWidth = 1.0 / [[UIScreen mainScreen] scale];
+    cell.borderWidth = 1.0f / [[UIScreen mainScreen] scale];
     
     // Thumbnail
     PHAssetCollection *assetCollection = self.assetCollections[indexPath.row];

--- a/QBImagePicker/QBCheckmarkView.m
+++ b/QBImagePicker/QBCheckmarkView.m
@@ -15,18 +15,18 @@
     [super awakeFromNib];
     
     // Set default values
-    self.borderWidth = 1.0;
-    self.checkmarkLineWidth = 1.2;
+    self.borderWidth = 1.0f;
+    self.checkmarkLineWidth = 1.2f;
     
     self.borderColor = [UIColor whiteColor];
-    self.bodyColor = [UIColor colorWithRed:(20.0 / 255.0) green:(111.0 / 255.0) blue:(223.0 / 255.0) alpha:1.0];
+    self.bodyColor = [UIColor colorWithRed:(20.0f / 255.0f) green:(111.0f / 255.0f) blue:(223.0f / 255.0f) alpha:1.0f];
     self.checkmarkColor = [UIColor whiteColor];
     
     // Set shadow
     self.layer.shadowColor = [[UIColor grayColor] CGColor];
     self.layer.shadowOffset = CGSizeMake(0, 0);
-    self.layer.shadowOpacity = 0.6;
-    self.layer.shadowRadius = 2.0;
+    self.layer.shadowOpacity = 0.6f;
+    self.layer.shadowRadius = 2.0f;
 }
 
 - (void)drawRect:(CGRect)rect
@@ -43,9 +43,9 @@
     UIBezierPath *checkmarkPath = [UIBezierPath bezierPath];
     checkmarkPath.lineWidth = self.checkmarkLineWidth;
     
-    [checkmarkPath moveToPoint:CGPointMake(CGRectGetWidth(self.bounds) * (6.0 / 24.0), CGRectGetHeight(self.bounds) * (12.0 / 24.0))];
-    [checkmarkPath addLineToPoint:CGPointMake(CGRectGetWidth(self.bounds) * (10.0 / 24.0), CGRectGetHeight(self.bounds) * (16.0 / 24.0))];
-    [checkmarkPath addLineToPoint:CGPointMake(CGRectGetWidth(self.bounds) * (18.0 / 24.0), CGRectGetHeight(self.bounds) * (8.0 / 24.0))];
+    [checkmarkPath moveToPoint:CGPointMake(CGRectGetWidth(self.bounds) * (6.0f / 24.0f), CGRectGetHeight(self.bounds) * (12.0f / 24.0f))];
+    [checkmarkPath addLineToPoint:CGPointMake(CGRectGetWidth(self.bounds) * (10.0f / 24.0f), CGRectGetHeight(self.bounds) * (16.0f / 24.0f))];
+    [checkmarkPath addLineToPoint:CGPointMake(CGRectGetWidth(self.bounds) * (18.0f / 24.0f), CGRectGetHeight(self.bounds) * (8.0f / 24.0f))];
     
     [self.checkmarkColor setStroke];
     [checkmarkPath stroke];

--- a/QBImagePicker/QBSlomoIconView.m
+++ b/QBImagePicker/QBSlomoIconView.m
@@ -22,13 +22,13 @@
 {
     [self.iconColor setStroke];
     
-    CGFloat width = 2.2;
+    CGFloat width = 2.2f;
     CGRect insetRect = CGRectInset(rect, width / 2, width / 2);
     
     // Draw dashed circle
     UIBezierPath* circlePath = [UIBezierPath bezierPathWithOvalInRect:insetRect];
     circlePath.lineWidth = width;
-    CGFloat ovalPattern[] = {0.75, 0.75};
+    CGFloat ovalPattern[] = {0.75f, 0.75f};
     [circlePath setLineDash:ovalPattern count:2 phase:0];
     [circlePath stroke];
 }

--- a/QBImagePicker/QBVideoIconView.m
+++ b/QBImagePicker/QBVideoIconView.m
@@ -31,7 +31,7 @@
     [trianglePath fill];
     
     // Draw rounded square
-    UIBezierPath *squarePath = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(CGRectGetMinX(self.bounds), CGRectGetMinY(self.bounds), CGRectGetWidth(self.bounds) - CGRectGetMidY(self.bounds) - 1.0, CGRectGetHeight(self.bounds)) cornerRadius:2.0];
+    UIBezierPath *squarePath = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(CGRectGetMinX(self.bounds), CGRectGetMinY(self.bounds), CGRectGetWidth(self.bounds) - CGRectGetMidY(self.bounds) - 1.0f, CGRectGetHeight(self.bounds)) cornerRadius:2.0f];
     [squarePath fill];
 }
 


### PR DESCRIPTION
1. fix from PR #180, but with missing `}` added. `: `Fatal Exception: NSInternalInconsistencyException attempt to delete and reload the same index path`
2. fix for `Fatal Exception: NSInvalidArgumentException *** -[NSPlaceholderString initWithString:]: nil argument`
3. fix for `Fatal Exception: NSInternalInconsistencyException negative sizes are not supported in the flow layout`
4. added type safety by explicitly setting some double literals to floats for `Parameter type mismatch: Values of type 'double' may not fit into the receiver type 'CGFloat'`